### PR TITLE
Added install locales step to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER "vccw-team"
 
+RUN apt-get clean && apt-get update && apt-get install -y locales
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en


### PR DESCRIPTION
The `locale-gen` command does not seem to be available by default when pulling ubuntu:16.04.
The addition of this statement ensures that the `locale-gen` command is installed.